### PR TITLE
Quickfix requirements

### DIFF
--- a/requrements.txt
+++ b/requrements.txt
@@ -7,5 +7,8 @@ future==0.18.2
 filelock==3.0.12
 setproctitle==1.1.10
 wandb==0.12.0
-dataclasses=0.8
+dataclasses
 Pillow==8.3.1
+numpy<=1.20
+setuptools==59.5.0
+protobuf<=3.20.0


### PR DESCRIPTION
Tried to run repo locally, got stopped at the requirements install step.

After changes in this PR, this works:
```
uv venv -p 3.9 .venv
uv pip install -p 3.9 -r requirements.txt
source .venv/bin/activate.fish
python run.py cogs/trafo.yaml
```

The PR fixes errors (root cause is always some place where Tensorboard is being annoying):
```
`np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.


from torch.utils.tensorboard.writer import SummaryWriter
AttributeError: module 'distutils' has no attribute 'version'


1. Downgrade the protobuf package to 3.20.x or lower.
TypeError: Descriptors cannot be created directly.
```

Alternative might be changing the pinned Tensorboard version but then probably other requirements become out-of-sync with original runs.
